### PR TITLE
Fixed: Can't add new notification in functions.php

### DIFF
--- a/slack.php
+++ b/slack.php
@@ -34,8 +34,8 @@ require_once __DIR__ . '/includes/autoloader.php';
 // Register the autoloader.
 WP_Slack_Autoloader::register( 'WP_Slack', trailingslashit( plugin_dir_path( __FILE__ ) ) . '/includes/' );
 
-// Runs this plugin after all plugins are loaded.
-add_action( 'plugins_loaded', function() {
+// Runs this plugin after the theme is loaded.
+add_action( 'after_setup_theme', function() {
 	$GLOBALS['wp_slack'] = new WP_Slack_Plugin();
 	$GLOBALS['wp_slack']->run( __FILE__ );
 });


### PR DESCRIPTION
Because the code fired after the plugins loaded, but before the theme itself loaded - you couldn't add custom notifications in your functions.php file (or other theme's file).
Changing the code to fire after the theme has loaded fixed it. 
